### PR TITLE
Redirect link fix

### DIFF
--- a/controllers/linkController.js
+++ b/controllers/linkController.js
@@ -8,7 +8,6 @@ exports.normalizeUrl = (req, res, next) => {
 	try {
 		req.body.url = normalize(req.body.url, {
 			forceHttps: true,
-			stripWWW: true,
 		});
 	} catch (err) {
 		// The normalizeURL library throws errors, but this is more descriptive.

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -115,7 +115,7 @@ describe('POST link/next route', function () {
 			.send({ url: 'https://reddit.com/r/akfgwauifgweahyfshfkawhfka' })
 			.end((err, res) => {
 				expect(res.error.text).to.be.equal(
-					'ERROR! Message: https://reddit.com/r/akfgwauifgweahyfshfkawhfka is not a valid grapharoo link.',
+					'ERROR! Message: https://reddit.com/r/akfgwauifgweahyfshfkawhfka is not a valid grapharoo link',
 				);
 				done(err);
 			});
@@ -128,7 +128,7 @@ describe('POST link/next route', function () {
 			.send({ url: 'https://youtube.com/' })
 			.end((err, res) => {
 				expect(res.error.text).to.be.equal(
-					'ERROR! Message: https://youtube.com/ is not a valid domain.',
+					'ERROR! Message: https://www.youtube.com/ is not a valid domain',
 				);
 				done(err);
 			});
@@ -162,7 +162,7 @@ describe('POST link/next route', function () {
 	it("Redirecting link will go to the final destination and return the same 'next' as original link", (done) => {
 		chai
 			.request(url)
-			.port('/link/next')
+			.post('/link/next')
 			.send({ url: `${testRedirectURL}` })
 			.end((err, res) => {
 				expect(res?.body?.next?.url).to.equal(
@@ -179,7 +179,7 @@ describe('POST link/next route', function () {
 			.send({ url: 'https://sv.facebook.com' })
 			.end((err, res) => {
 				expect(res.error.text).to.be.equal(
-					'ERROR! Message: https://facebook.com/ is not a valid domain.',
+					'ERROR! Message: https://www.facebook.com/ is not a valid domain',
 				);
 				done(err);
 			});

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -10,6 +10,8 @@ require('dotenv').config({ path: '../.env' });
 const url = `http://localhost:${process.env.PORT || 3000}`;
 
 const testURL = 'https://www.reddit.com/r/aww/comments/hd6xtp/comment/fvk5vao';
+const testRedirectURL =
+	'https://aww.reddit.com/comments/hd6xtp/comment/fvk5vao';
 
 describe('POST link/next route', function () {
 	// Avoid timeout from network calls. This affects the whole suite.
@@ -153,6 +155,19 @@ describe('POST link/next route', function () {
 			.end((err, res) => {
 				const posted = res.body.link.data.created_utc;
 				expect(new Date(posted).toDateString()).to.include('2020');
+				done(err);
+			});
+	});
+
+	it("Redirecting link will go to the final destination and return the same 'next' as original link", (done) => {
+		chai
+			.request(url)
+			.port('/link/next')
+			.send({ url: `${testRedirectURL}` })
+			.end((err, res) => {
+				expect(res?.body?.next?.url).to.equal(
+					'https://reddit.com/r/pics/comments/hd4tek/comment/fvjpc68',
+				);
 				done(err);
 			});
 	});

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -171,4 +171,17 @@ describe('POST link/next route', function () {
 				done(err);
 			});
 	});
+
+	it('Redirecting link to an invalid host should result in same error as other incorrect link', (done) => {
+		chai
+			.request(url)
+			.post('/link/next')
+			.send({ url: 'https://sv.facebook.com' })
+			.end((err, res) => {
+				expect(res.error.text).to.be.equal(
+					'ERROR! Message: https://facebook.com/ is not a valid domain.',
+				);
+				done(err);
+			});
+	});
 });


### PR DESCRIPTION
This fixes redirects being treated as different links.

Right now the flow of /link/next is:
1. Req comes in, is normalized.
2. Normalized url is peeked at, using a HEAD request, which will find the true destination URL (as if you clicked it).
3. Final URL is checked for in and the result is returned.